### PR TITLE
#17 - [Week9] 내가 진행 중인 미션 목록 조회 API

### DIFF
--- a/src/main/java/com/study/controller/MemberRestController.java
+++ b/src/main/java/com/study/controller/MemberRestController.java
@@ -2,6 +2,7 @@ package com.study.controller;
 
 import com.study.apiPayload.ApiResponse;
 import com.study.converter.MemberConverter;
+import com.study.converter.MemberMissionConverter;
 import com.study.converter.ReviewConverter;
 import com.study.domain.Member;
 import com.study.domain.Review;
@@ -13,11 +14,11 @@ import com.study.dto.response.MemberMissionResponseDTO;
 import com.study.dto.response.MemberResponseDTO;
 import com.study.dto.response.ReviewResponseDTO;
 import com.study.service.MemberMissionService.MemberMissionCommandService;
+import com.study.service.MemberMissionService.MemberMissionQueryService;
 import com.study.service.MemberService.MemberCommandService;
 import com.study.service.MemberService.MemberQueryService;
 import com.study.service.ReviewService.ReviewCommandService;
 import com.study.validation.annotation.ExistMember;
-import com.study.validation.annotation.ExistStore;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -37,25 +38,45 @@ public class MemberRestController {
     private final MemberQueryService memberQueryService;
     private final MemberMissionCommandService memberMissionCommandService;
     private final ReviewCommandService reviewCommandService;
+    private final MemberMissionQueryService memberMissionQueryService;
     @PostMapping("/")
     @Operation(summary = "회원가입 API")
     public ApiResponse<MemberResponseDTO.JoinResultDto> join(@RequestBody @Valid MemberRequestDTO.JoinDto request){
         Member member = memberCommandService.joinMember(request);
         return ApiResponse.onSuccess(MemberConverter.toJoinResultDto(member));
     }
-    @PostMapping("/missions/{memberId}/{missionId}/")
-    @Operation(summary = "멤버 미션 상태 수정 API")
-    public ApiResponse<MemberMissionResponseDTO.updateMemberMissionStatusResultDto> updateMemberMissionStatus(
-            @RequestBody @Valid MemberMissionRequestDTO.updateMemberMissionStatusDto request,
+    @PostMapping("/{memberId}/missions/{missionId}/")
+    @Operation(summary = "멤버 미션 상태 수정 API", description = "멤버와 미션의 ID를 둘 다 받아서, 임의로 미션의 상태를 수정할 수 있음")
+    public ApiResponse<MemberMissionResponseDTO.MemberMissionStatusResultDto> updateMemberMissionStatus(
+            @RequestBody @Valid MemberMissionRequestDTO.MemberMissionStatusDto request,
             @PathVariable Long memberId,
             @PathVariable Long missionId) {
 
         MemberMission memberMission = memberMissionCommandService.updateMemberMissionStatus(request, memberId, missionId);
-        MemberMissionResponseDTO.updateMemberMissionStatusResultDto responseDto = MemberMissionResponseDTO.updateMemberMissionStatusResultDto.builder()
+        MemberMissionResponseDTO.MemberMissionStatusResultDto responseDto = MemberMissionResponseDTO.MemberMissionStatusResultDto.builder()
                 .updatedAt(memberMission.getUpdatedAt())
                 .build();
 
         return ApiResponse.onSuccess(responseDto);
+    }
+
+
+
+    @GetMapping("/{memberId}/missions")
+    @Operation(summary = "진행 중인 리스트 조회 API", description = "내가 진행중인 미션 들을 조회하는 API이며, 페이징을 포함. query string으로 page 번호를 주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @Parameters({
+            @Parameter(name = "memberId", description = "스프링 시큐리티 적용 전이라 path-variable 로 받아옴")
+    })
+    public ApiResponse<MemberMissionResponseDTO.MemberMissionPreviewListDTO> getChallengingMissionList(@ExistMember @PathVariable(name = "memberId") Long memberId, @RequestParam(name = "page") Integer page){
+        Page<MemberMission> memberMissionList = memberMissionQueryService.getChallengingMissionList(memberId, page);
+
+        return ApiResponse.onSuccess(MemberMissionConverter.memberMissionPreviewListDTO(memberMissionList));
     }
 
     @PostMapping("/reviews")
@@ -83,6 +104,4 @@ public class MemberRestController {
         return ApiResponse.onSuccess(ReviewConverter.reviewPreViewListDTO(reviewList));
     }
 
-//    @DeleteMapping("/reviews/{reviewId}")
-//    @Operation(summary = "리뷰 삭제 API")
 }

--- a/src/main/java/com/study/converter/MemberMissionConverter.java
+++ b/src/main/java/com/study/converter/MemberMissionConverter.java
@@ -1,0 +1,33 @@
+package com.study.converter;
+
+import com.study.domain.mapping.MemberMission;
+import com.study.dto.response.MemberMissionResponseDTO;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public class MemberMissionConverter {
+
+    public static MemberMissionResponseDTO.MemberMissionPreviewDTO memberMissionPreviewDTO(MemberMission memberMission){
+        return MemberMissionResponseDTO.MemberMissionPreviewDTO.builder()
+                .storeName(memberMission.getMission().getStore().getName())
+                .missionSpec(memberMission.getMission().getMissionSpec())
+                .deadLine(memberMission.getMission().getDeadline())
+                .reward(memberMission.getMission().getReward())
+                .status(memberMission.getStatus())
+                .build();
+    }
+
+    public static MemberMissionResponseDTO.MemberMissionPreviewListDTO memberMissionPreviewListDTO(Page<MemberMission> memberMissionList){
+        List<MemberMissionResponseDTO.MemberMissionPreviewDTO> memberMissionPreviewDTOList = memberMissionList.stream()
+                .map(MemberMissionConverter::memberMissionPreviewDTO).toList();
+        return MemberMissionResponseDTO.MemberMissionPreviewListDTO.builder()
+                .isLast(memberMissionList.isLast())
+                .isFirst(memberMissionList.isFirst())
+                .totalPage(memberMissionList.getTotalPages())
+                .totalElements(memberMissionList.getTotalElements())
+                .listSize(memberMissionList.getSize())
+                .memberMissionList(memberMissionPreviewDTOList)
+                .build();
+    }
+}

--- a/src/main/java/com/study/dto/request/MemberMissionRequestDTO.java
+++ b/src/main/java/com/study/dto/request/MemberMissionRequestDTO.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 public class MemberMissionRequestDTO {
     @Getter
-    public static class updateMemberMissionStatusDto {
+    public static class MemberMissionStatusDto {
         @NotNull
         String status;
     }

--- a/src/main/java/com/study/dto/response/MemberMissionResponseDTO.java
+++ b/src/main/java/com/study/dto/response/MemberMissionResponseDTO.java
@@ -1,20 +1,47 @@
 package com.study.dto.response;
 
+import com.study.domain.Mission;
 import com.study.domain.enums.MissionStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class MemberMissionResponseDTO {
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class updateMemberMissionStatusResultDto{
+    public static class MemberMissionStatusResultDto {
         LocalDateTime updatedAt;
+    }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberMissionPreviewDTO{
+        String storeName;
+        String missionSpec;
+        LocalDate deadLine;
+        Integer reward;
+        MissionStatus status;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberMissionPreviewListDTO{
+        List<MemberMissionPreviewDTO> memberMissionList;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
     }
 }

--- a/src/main/java/com/study/repository/MemberMissionRepository/MemberMissionRepositoryCustom.java
+++ b/src/main/java/com/study/repository/MemberMissionRepository/MemberMissionRepositoryCustom.java
@@ -4,12 +4,15 @@ import com.study.domain.Member;
 import com.study.domain.Mission;
 import com.study.domain.enums.MissionStatus;
 import com.study.domain.mapping.MemberMission;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface MemberMissionRepositoryCustom {
     List<MemberMission> dynamicQueryWithBooleanBuilder(Long memberId, MissionStatus missionStatus);
-
+    Page<MemberMission> findAllByMemberAndChallengingMissionStatus(Long memberId, Pageable pageable);
     MemberMission findByMemberAndMission(Member member, Mission mission);
 }

--- a/src/main/java/com/study/repository/MemberMissionRepository/MemberMissionRepositoryImpl.java
+++ b/src/main/java/com/study/repository/MemberMissionRepository/MemberMissionRepositoryImpl.java
@@ -9,16 +9,20 @@ import com.study.domain.enums.MissionStatus;
 import com.study.domain.mapping.MemberMission;
 import com.study.domain.mapping.QMemberMission;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 
 @Repository
 @RequiredArgsConstructor
 public class MemberMissionRepositoryImpl implements MemberMissionRepositoryCustom {
     private final JPQLQueryFactory jpqlQueryFactory;
-
     private final QMemberMission memberMission = QMemberMission.memberMission;
     private final QMember member = QMember.member;
 
@@ -38,8 +42,39 @@ public class MemberMissionRepositoryImpl implements MemberMissionRepositoryCusto
                 .join(memberMission.member, member).fetchJoin()
                 .where(predicate)
                 .fetch();
-
     }
+    @Override
+    public Page<MemberMission> findAllByMemberAndChallengingMissionStatus(Long memberId, Pageable pageable) {
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        if (memberId != null) {
+            predicate.and(memberMission.member.id.eq(memberId));
+        }
+
+        // 데이터 조회
+        List<MemberMission> content = jpqlQueryFactory
+                .selectFrom(memberMission)
+                .join(memberMission.member, member).fetchJoin()
+                .where(predicate)
+                .where(memberMission.status.eq(MissionStatus.CHALLENGING))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 전체 데이터 개수 조회 (Null 처리)
+        long total = Optional.ofNullable(
+                jpqlQueryFactory
+                        .select(memberMission.count())
+                        .from(memberMission)
+                        .where(predicate)
+                        .where(memberMission.status.eq(MissionStatus.CHALLENGING))
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+
     @Override
     public MemberMission findByMemberAndMission(Member member, Mission mission) {
         return jpqlQueryFactory

--- a/src/main/java/com/study/service/MemberMissionService/MemberMissionCommandService.java
+++ b/src/main/java/com/study/service/MemberMissionService/MemberMissionCommandService.java
@@ -4,5 +4,5 @@ import com.study.domain.mapping.MemberMission;
 import com.study.dto.request.MemberMissionRequestDTO;
 
 public interface MemberMissionCommandService {
-    MemberMission updateMemberMissionStatus(MemberMissionRequestDTO.updateMemberMissionStatusDto request, Long memberId, Long missionId);
+    MemberMission updateMemberMissionStatus(MemberMissionRequestDTO.MemberMissionStatusDto request, Long memberId, Long missionId);
 }

--- a/src/main/java/com/study/service/MemberMissionService/MemberMissionCommandServiceImpl.java
+++ b/src/main/java/com/study/service/MemberMissionService/MemberMissionCommandServiceImpl.java
@@ -5,7 +5,6 @@ import com.study.apiPayload.code.exception.handler.MissionHandler;
 import com.study.apiPayload.code.status.ErrorStatus;
 import com.study.domain.Member;
 import com.study.domain.Mission;
-import com.study.domain.enums.MemberStatus;
 import com.study.domain.enums.MissionStatus;
 import com.study.domain.mapping.MemberMission;
 import com.study.dto.request.MemberMissionRequestDTO;
@@ -25,7 +24,7 @@ public class MemberMissionCommandServiceImpl implements MemberMissionCommandServ
     private final MemberMissionRepository memberMissionRepository;
     @Override
     @Transactional
-    public MemberMission updateMemberMissionStatus(MemberMissionRequestDTO.updateMemberMissionStatusDto request,
+    public MemberMission updateMemberMissionStatus(MemberMissionRequestDTO.MemberMissionStatusDto request,
                                                    Long memberId,
                                                    Long missionId) {
         // Member와 Mission 조회

--- a/src/main/java/com/study/service/MemberMissionService/MemberMissionQueryService.java
+++ b/src/main/java/com/study/service/MemberMissionService/MemberMissionQueryService.java
@@ -2,6 +2,8 @@ package com.study.service.MemberMissionService;
 
 import com.study.domain.enums.MissionStatus;
 import com.study.domain.mapping.MemberMission;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,4 +11,6 @@ import java.util.Optional;
 public interface MemberMissionQueryService {
     Optional<MemberMission> findMemberMissions(Long id);
     List<MemberMission> findMemberMissionsByNameAndMissionStatus(Long memberId, MissionStatus missionStatus);
+
+    Page<MemberMission> getChallengingMissionList(Long memberId, Integer page);
 }

--- a/src/main/java/com/study/service/MemberMissionService/MemberMissionQueryServiceImpl.java
+++ b/src/main/java/com/study/service/MemberMissionService/MemberMissionQueryServiceImpl.java
@@ -1,10 +1,14 @@
 package com.study.service.MemberMissionService;
 
+import com.study.domain.Member;
 import com.study.domain.enums.MissionStatus;
 import com.study.domain.mapping.MemberMission;
 import com.study.repository.MemberMissionRepository.MemberMissionRepository;
+import com.study.repository.MemberRepository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +21,7 @@ import java.util.Optional;
 @Transactional(readOnly= true)
 public class MemberMissionQueryServiceImpl implements MemberMissionQueryService {
     private final MemberMissionRepository memberMissionRepository;
+    private final MemberRepository memberRepository;
 
     @Override
     public Optional<MemberMission> findMemberMissions(Long id) {
@@ -29,5 +34,11 @@ public class MemberMissionQueryServiceImpl implements MemberMissionQueryService 
         List<MemberMission> filteredMemberMissions =memberMissionRepository.dynamicQueryWithBooleanBuilder(memberId,missionStatus);
         filteredMemberMissions.forEach(memberMission -> System.out.println("MemberMission: "+memberMission));
         return filteredMemberMissions;
+    }
+
+    @Override
+    public Page<MemberMission> getChallengingMissionList(Long memberId, Integer page) {
+        Page<MemberMission> MemberMissionPage = memberMissionRepository.findAllByMemberAndChallengingMissionStatus(memberId, PageRequest.of(page,10));
+        return MemberMissionPage;
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
This closed #17

## 💻 작업 내용
- 응답과 요청 DTO 생성
   - MemberMissionResponseDTO > MemberMissionPreviewDTO, MemberMissionPreviewListDTO
   -> memberMission 목록을 조회해야하니 list로 DTO를 하나 더 만들어줌

- 컨트롤러 : 반환값, 파라미터, URI, HTTP method 결정
   - Get, /{memberId}/missions : spring security 적용 전이라, path-variable로 memberId 받아줌 -> 이후 수정 필요
   - 페이징 포함. 프론트엔드로부터 query string으로 page 번호 받아옴
  
- 컨버터 정의
  - MemberMissionConverter > memberMissionPreviewDTO, memberMissionPreviewListDTO -> list는 stream()을 통해서 받아옴

- 서비스 메서드 로직 작성 + 레포지토리 메서드 작성
   - repository : 'CHALLENGING' 상태인 미션만 받아와야하기 때문에, Querydsl을 사용하여 데이터 조회하는 것으로 구현

## 📢 기타 사항
- 🤔 MemberMissionConverter > memberMissionPreviewDTO에서 build할 때, membermission - mission - store - name 이런 식으로 계속 타고타고 들어가는데 이게 성능상 좋은 방식인지 의문
- 🤔 Querydsl이 최선이었나 고민