### PR TITLE
[Week9] 특정 가게 미션 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/study/controller/StoreRestController.java
+++ b/src/main/java/com/study/controller/StoreRestController.java
@@ -1,18 +1,28 @@
 package com.study.controller;
 
 import com.study.apiPayload.ApiResponse;
+import com.study.converter.MissionConverter;
 import com.study.converter.ReviewConverter;
 import com.study.converter.StoreConverter;
+import com.study.domain.Mission;
 import com.study.domain.Review;
 import com.study.domain.Store;
+import com.study.domain.mapping.MemberMission;
+import com.study.dto.request.MemberMissionRequestDTO;
 import com.study.dto.request.ReviewRequestDTO;
 import com.study.dto.request.StoreRequestDTO;
+import com.study.dto.response.MemberMissionResponseDTO;
+import com.study.dto.response.MissionResponseDTO;
 import com.study.dto.response.ReviewResponseDTO;
 import com.study.dto.response.StoreResponseDTO;
+import com.study.service.MemberMissionService.MemberMissionCommandService;
+import com.study.service.MissionService.MissionQueryService;
 import com.study.service.ReviewService.ReviewCommandService;
+import com.study.service.ReviewService.ReviewQueryService;
 import com.study.service.StoreService.StoreCommandService;
 import com.study.service.StoreService.StoreQueryService;
 import com.study.validation.annotation.ExistStore;
+import com.sun.source.doctree.SummaryTree;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -29,7 +39,8 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/stores/")
 public class StoreRestController {
     private final StoreCommandService storeCommandService;
-    private final StoreQueryService storeQueryService;
+    private final ReviewQueryService reviewQueryService;
+    private final MissionQueryService missionQueryService;
 
     @PostMapping("/")
     public ApiResponse<StoreResponseDTO. addStoreToSpecificRegionResultDto> addStore(@RequestBody @Valid StoreRequestDTO.addStoreToSpecificRegionDto request){
@@ -49,9 +60,26 @@ public class StoreRestController {
             @Parameter(name = "storeId", description = "가게의 아이디, path variable 입니다!")
     })
     public ApiResponse<ReviewResponseDTO.ReviewPreViewListDTO> getReviewList(@ExistStore @PathVariable(name = "storeId") Long storeId, @RequestParam(name = "page") Integer page){
-        Page<Review> reviewList = storeQueryService.getReviewList(storeId, page);
+        Page<Review> reviewList = reviewQueryService.getReviewList(storeId, page);
         return ApiResponse.onSuccess(ReviewConverter.reviewPreViewListDTO(reviewList));
     }
+
+    @GetMapping("/{storeId}/missions")
+    @Operation(summary = "특정 가게의 미션 목록 조회 API", description = "특정 가게의 미션들을 조회하는 API이며, 페이징을 포함합니다. query String으로 Page 번호를 주세요")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @Parameters({
+            @Parameter(name = "storeId", description = "가게의 아이디, path variable 입니다!")
+    })
+    public ApiResponse<MissionResponseDTO.MissionPreViewListDTO> getMissionList(@ExistStore @PathVariable(name = "storeId") Long storeId, @RequestParam(name = "page") Integer page){
+        Page<Mission> missionList = missionQueryService.getMissionList(storeId, page);
+        return ApiResponse.onSuccess(MissionConverter.missionPreViewListDTO(missionList));
+    }
+
 
 //    @GetMapping("/")
 //    @Operation(summary = "가게 리스트 조회 API", description = "전체 가게의 리스트를 조회하는 API")

--- a/src/main/java/com/study/converter/MissionConverter.java
+++ b/src/main/java/com/study/converter/MissionConverter.java
@@ -4,8 +4,10 @@ import com.study.domain.Mission;
 import com.study.domain.Store;
 import com.study.dto.request.MissionRequestDTO;
 import com.study.dto.response.MissionResponseDTO;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class MissionConverter {
     public static MissionResponseDTO.addMissionToStoreResultDto toAddMission(Mission mission){
@@ -23,5 +25,27 @@ public class MissionConverter {
                 .missionSpec(request.getMissionSpec())
                 .build();
 
+    }
+
+    public static MissionResponseDTO.MissionPreViewDTO missionPreViewDTO(Mission mission){
+        return MissionResponseDTO.MissionPreViewDTO.builder()
+                .storeName(mission.getStore().getName())
+                .reward(mission.getReward())
+                .deadline(mission.getDeadline())
+                .missionSpec(mission.getMissionSpec())
+                .build();
+    }
+
+    public static MissionResponseDTO.MissionPreViewListDTO missionPreViewListDTO(Page<Mission> missionList){
+        List<MissionResponseDTO.MissionPreViewDTO> missionPreViewDTOList = missionList.stream()
+                .map(MissionConverter::missionPreViewDTO).toList();
+        return MissionResponseDTO.MissionPreViewListDTO.builder()
+                .isLast(missionList.isLast())
+                .isFirst(missionList.isFirst())
+                .totalPage(missionList.getTotalPages())
+                .totalElements(missionList.getTotalElements())
+                .listSize(missionPreViewDTOList.size())
+                .missionList(missionPreViewDTOList)
+                .build();
     }
 }

--- a/src/main/java/com/study/dto/response/MissionResponseDTO.java
+++ b/src/main/java/com/study/dto/response/MissionResponseDTO.java
@@ -4,7 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class MissionResponseDTO {
     @Builder
@@ -14,5 +17,32 @@ public class MissionResponseDTO {
     public static class addMissionToStoreResultDto{
         Long missionId;
         LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MissionPreViewDTO{
+        String storeName;
+        Integer reward;
+        LocalDate deadline;
+        String missionSpec;
+
+
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MissionPreViewListDTO{
+        List<MissionPreViewDTO> missionList;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+
     }
 }

--- a/src/main/java/com/study/repository/MissionRepository/MissionRepository.java
+++ b/src/main/java/com/study/repository/MissionRepository/MissionRepository.java
@@ -1,8 +1,12 @@
 package com.study.repository.MissionRepository;
 
 import com.study.domain.Mission;
+import com.study.domain.Store;
 import com.study.domain.mapping.MemberMission;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MissionRepository extends JpaRepository<Mission, Long>, MissionRepositoryCustom {
+    Page<Mission> findAllByStore(Store store, PageRequest pageRequest);
 }

--- a/src/main/java/com/study/service/MissionService/MissionQueryService.java
+++ b/src/main/java/com/study/service/MissionService/MissionQueryService.java
@@ -1,12 +1,15 @@
 package com.study.service.MissionService;
 
 import com.study.domain.Mission;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface MissionQueryService {
     Optional<Mission> findMission(Long id);
+    Boolean existsById(Long missionId);
 
     List<Mission> findMissionByRegion(String regionName);
+    Page<Mission> getMissionList(Long StoreId, Integer page);
 }

--- a/src/main/java/com/study/service/MissionService/MissionQueryServiceImpl.java
+++ b/src/main/java/com/study/service/MissionService/MissionQueryServiceImpl.java
@@ -1,8 +1,12 @@
 package com.study.service.MissionService;
 
 import com.study.domain.Mission;
+import com.study.domain.Store;
 import com.study.repository.MissionRepository.MissionRepository;
+import com.study.repository.StoreRepository.StoreRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,9 +18,15 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 public class MissionQueryServiceImpl implements MissionQueryService {
     private final MissionRepository missionRepository;
+    private final StoreRepository storeRepository;
     @Override
     public Optional<Mission> findMission(Long id) {
         return missionRepository.findById(id);
+    }
+
+    @Override
+    public Boolean existsById(Long missionId) {
+        return missionRepository.existsById(missionId);
     }
 
     @Override
@@ -25,4 +35,12 @@ public class MissionQueryServiceImpl implements MissionQueryService {
         filteredMissions.forEach(mission -> System.out.println("Mission: "+ mission));
         return filteredMissions;
     }
+
+    @Override
+    public Page<Mission> getMissionList(Long StoreId, Integer page) {
+        Store store = storeRepository.findById(StoreId).get();
+        Page<Mission> missionPage = missionRepository.findAllByStore(store, PageRequest.of(page,10));
+        return missionPage;
+    }
+
 }

--- a/src/main/java/com/study/service/ReviewService/ReviewQueryService.java
+++ b/src/main/java/com/study/service/ReviewService/ReviewQueryService.java
@@ -6,4 +6,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface ReviewQueryService {
     public Page<Review> findReviewsByStoreName(String storeName, Integer page, Integer size);
+    Page<Review> getReviewList(Long StoreId, Integer page);
 }

--- a/src/main/java/com/study/service/ReviewService/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/study/service/ReviewService/ReviewQueryServiceImpl.java
@@ -1,8 +1,10 @@
 package com.study.service.ReviewService;
 
 import com.study.domain.Review;
+import com.study.domain.Store;
 import com.study.repository.ReviewRepository.ReviewRepository;
 import com.study.repository.ReviewRepository.ReviewRepositoryCustom;
+import com.study.repository.StoreRepository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ReviewQueryServiceImpl implements ReviewQueryService {
     private final ReviewRepository reviewRepository;
+    private final StoreRepository storeRepository;
 
     @Override
     public Page<Review> findReviewsByStoreName(String storeName, Integer page, Integer size) {
@@ -30,5 +33,12 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
         reviewsPage.getContent().forEach(System.out::println);
 
         return reviewsPage;
+    }
+
+    @Override
+    public Page<Review> getReviewList(Long StoreId, Integer page) {
+        Store store = storeRepository.findById(StoreId).get();
+        Page<Review> reviewPage = reviewRepository.findAllByStore(store, PageRequest.of(page,10));
+        return reviewPage;
     }
 }

--- a/src/main/java/com/study/service/StoreService/StoreQueryService.java
+++ b/src/main/java/com/study/service/StoreService/StoreQueryService.java
@@ -11,5 +11,5 @@ public interface StoreQueryService {
     Optional<Store> findStore(Long id);
     List<Store> findStoresByNameAndScore(String name, Float score);
 
-    Page<Review> getReviewList(Long StoreId, Integer page);
+
 }

--- a/src/main/java/com/study/service/StoreService/StoreQueryServiceImpl.java
+++ b/src/main/java/com/study/service/StoreService/StoreQueryServiceImpl.java
@@ -35,10 +35,5 @@ public class StoreQueryServiceImpl implements StoreQueryService{
         return filteredStores;
     }
 
-    @Override
-    public Page<Review> getReviewList(Long StoreId, Integer page) {
-        Store store = storeRepository.findById(StoreId).get();
-        Page<Review> StorePage = reviewRepository.findAllByStore(store, PageRequest.of(page,10));
-        return StorePage;
-    }
+
 }

--- a/src/main/java/com/study/validation/annotation/ExistMission.java
+++ b/src/main/java/com/study/validation/annotation/ExistMission.java
@@ -1,0 +1,4 @@
+package com.study.validation.annotation;
+
+public @interface ExistMission {
+}

--- a/src/main/java/com/study/validation/validator/MissionExistValidator.java
+++ b/src/main/java/com/study/validation/validator/MissionExistValidator.java
@@ -1,0 +1,30 @@
+package com.study.validation.validator;
+
+import com.study.apiPayload.code.status.ErrorStatus;
+import com.study.service.MissionService.MissionQueryService;
+import com.study.validation.annotation.ExistMission;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MissionExistValidator implements ConstraintValidator<ExistMission, Long>  {
+    private final MissionQueryService missionQueryService;
+    @Override
+    public void initialize(ExistMission constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long missionId, ConstraintValidatorContext context) {
+        boolean isValid = missionQueryService.existsById(missionId);
+
+        if(!isValid){
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.MISSION_NOT_FOUND.toString()).addConstraintViolation();
+        }
+        return isValid;
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호
This closed #23 

## 💻 작업 내용
- 응답과 요청 DTO 생성
   - MissionResponseDTO > MissionPreViewDTO, MissionPreViewListDTO : 목록이기 때문에 조회할 DTO를 하나 더 추가
- 컨트롤러 MissionRestController > GetMissionList : 반환값, 파라미터, URI, HTTP method 결정
- 컨버터 정의 MissionConverter > missionPreViewDTO, missionPreViewListDTO -> listDTO는 stream() 통해서 받아옴
  
## 📢 기타 사항
- 특정 가게 리뷰 목록 조회 API 구현 중 getReviewList를 StoreQueryService에 구현했었음 -> 이를 ReviewQueryService에 구현하여, 위치를 명확히 수정
- 이후 사용 가능성을 고려하여 ExistMission MissionExistValidator 생성해둠