### PR TITLE
#25 - [Week9] CheckPage CustomAnnotation 구현

### DIFF
--- a/src/main/java/com/study/apiPayload/code/exception/CustomValidationException.java
+++ b/src/main/java/com/study/apiPayload/code/exception/CustomValidationException.java
@@ -1,0 +1,22 @@
+package com.study.apiPayload.code.exception;
+
+import com.study.apiPayload.code.BaseErrorCode;
+import com.study.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomValidationException extends RuntimeException {
+    private final BaseErrorCode code;
+
+    // 에러 사유를 반환
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    // HTTP 상태를 포함한 에러 사유 반환
+    public ErrorReasonDTO getErrorReasonHttpStatus() {
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/com/study/apiPayload/code/exception/ExceptionAdvice.java
+++ b/src/main/java/com/study/apiPayload/code/exception/ExceptionAdvice.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 @RestControllerAdvice(annotations = {RestController.class})
 public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
-
     @ExceptionHandler
     public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
         String errorMessage = e.getConstraintViolations().stream()
@@ -116,4 +115,24 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
                 request
         );
     }
+
+    @ExceptionHandler(CustomValidationException.class)
+    public ResponseEntity<Object> handleCustomValidationException(CustomValidationException e, WebRequest request) {
+        ErrorReasonDTO errorReason = e.getErrorReasonHttpStatus(); // 에러 정보 가져오기
+
+        ApiResponse<Object> body = ApiResponse.onFailure(
+                errorReason.getCode(),
+                errorReason.getMessage(),
+                null
+        );
+
+        return handleExceptionInternal(
+                e,
+                body,
+                HttpHeaders.EMPTY,
+                errorReason.getHttpStatus(),
+                request
+        );
+    }
+
 }

--- a/src/main/java/com/study/apiPayload/code/exception/PageHandlerResolver.java
+++ b/src/main/java/com/study/apiPayload/code/exception/PageHandlerResolver.java
@@ -1,0 +1,47 @@
+package com.study.apiPayload.code.exception;
+
+import com.study.apiPayload.code.status.ErrorStatus;
+import com.study.validation.annotation.CheckPage;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class PageHandlerResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // @CheckPage 어노테이션이 붙어 있는 Integer 타입 파라미터를 처리
+        return parameter.getParameterAnnotation(CheckPage.class) != null &&
+                parameter.getParameterType().equals(Integer.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        Integer page;
+        String pageParam = webRequest.getParameter("page");
+
+        try {
+            if (pageParam != null) {
+                page = Integer.parseInt(pageParam);
+            } else {
+                page = 0; // 기본값 설정
+            }
+        } catch (NumberFormatException ex) {
+            throw new CustomValidationException(ErrorStatus.INVALID_PAGE);
+        }
+
+        if (page < 0) {
+            throw new CustomValidationException(ErrorStatus.INVALID_PAGE);
+        }
+
+        // page 값을 -1로 조정
+        return Math.max(0, page - 1);
+    }
+}

--- a/src/main/java/com/study/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/study/apiPayload/code/status/ErrorStatus.java
@@ -27,7 +27,11 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_MISSION_NOT_FOUND(HttpStatus.NOT_FOUND,"MEMBER MISSION 4001", "해당 멤버 미션이 없습니다."),
     MISSION_STATUS_COMPLETE(HttpStatus.BAD_REQUEST,"MEMBER MISSION 4002", "미션이 진행 완료 상태 입니다."),
 
+    INVALID_PAGE(HttpStatus.BAD_REQUEST, "PAGE 4001", "잘못된 페이지 번호 입니다."),
+
+
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST,"TEMP4001", "이거는 테스트");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/study/config/WebConfig.java
+++ b/src/main/java/com/study/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.study.config;
+
+import com.study.apiPayload.code.exception.PageHandlerResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final PageHandlerResolver pageHandlerResolver;
+
+    public WebConfig(PageHandlerResolver pageHandlerResolver) {
+        this.pageHandlerResolver = pageHandlerResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(pageHandlerResolver);
+    }
+}
+

--- a/src/main/java/com/study/controller/MemberRestController.java
+++ b/src/main/java/com/study/controller/MemberRestController.java
@@ -7,7 +7,6 @@ import com.study.converter.ReviewConverter;
 import com.study.domain.Member;
 import com.study.domain.Review;
 import com.study.domain.mapping.MemberMission;
-import com.study.dto.request.MemberMissionRequestDTO;
 import com.study.dto.request.MemberRequestDTO;
 import com.study.dto.request.ReviewRequestDTO;
 import com.study.dto.response.MemberMissionResponseDTO;
@@ -18,6 +17,7 @@ import com.study.service.MemberMissionService.MemberMissionQueryService;
 import com.study.service.MemberService.MemberCommandService;
 import com.study.service.MemberService.MemberQueryService;
 import com.study.service.ReviewService.ReviewCommandService;
+import com.study.validation.annotation.CheckPage;
 import com.study.validation.annotation.ExistMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -60,7 +60,7 @@ public class MemberRestController {
     public ApiResponse<MemberMissionResponseDTO.MemberMissionPreviewListDTO> updateMemberMissionsStatus(
             @ExistMember
             @PathVariable(name = "memberId") Long memberId,
-            @RequestParam(name = "page") Integer page) {
+            @CheckPage Integer page) {
         Page<MemberMission> memberMissionList = memberMissionQueryService.findAndUpdateChallengingMissions(memberId, page);
 
         return ApiResponse.onSuccess(MemberMissionConverter.memberMissionPreviewListDTO(memberMissionList));
@@ -77,7 +77,9 @@ public class MemberRestController {
     @Parameters({
             @Parameter(name = "memberId", description = "스프링 시큐리티 적용 전이라 path-variable 로 받아옴")
     })
-    public ApiResponse<MemberMissionResponseDTO.MemberMissionPreviewListDTO> getChallengingMissionList(@ExistMember @PathVariable(name = "memberId") Long memberId, @RequestParam(name = "page") Integer page){
+    public ApiResponse<MemberMissionResponseDTO.MemberMissionPreviewListDTO> getChallengingMissionList(
+            @ExistMember @PathVariable(name = "memberId") Long memberId,
+            @CheckPage Integer page){
         Page<MemberMission> memberMissionList = memberMissionQueryService.getChallengingMissionList(memberId, page);
 
         return ApiResponse.onSuccess(MemberMissionConverter.memberMissionPreviewListDTO(memberMissionList));
@@ -103,7 +105,9 @@ public class MemberRestController {
     @Parameters({
             @Parameter(name = "memberId", description = "스프링 시큐리티 적용 전이라 path-variable 로 받아옴")
     })
-    public ApiResponse<ReviewResponseDTO.ReviewPreViewListDTO> getReviewList(@ExistMember @PathVariable(name = "memberId") Long memberId, @RequestParam(name = "page") Integer page){
+    public ApiResponse<ReviewResponseDTO.ReviewPreViewListDTO> getReviewList(
+            @ExistMember @PathVariable(name = "memberId") Long memberId,
+            @CheckPage Integer page){
         Page<Review> reviewList = memberQueryService.getReviewList(memberId, page);
         return ApiResponse.onSuccess(ReviewConverter.reviewPreViewListDTO(reviewList));
     }

--- a/src/main/java/com/study/controller/StoreRestController.java
+++ b/src/main/java/com/study/controller/StoreRestController.java
@@ -7,22 +7,15 @@ import com.study.converter.StoreConverter;
 import com.study.domain.Mission;
 import com.study.domain.Review;
 import com.study.domain.Store;
-import com.study.domain.mapping.MemberMission;
-import com.study.dto.request.MemberMissionRequestDTO;
-import com.study.dto.request.ReviewRequestDTO;
 import com.study.dto.request.StoreRequestDTO;
-import com.study.dto.response.MemberMissionResponseDTO;
 import com.study.dto.response.MissionResponseDTO;
 import com.study.dto.response.ReviewResponseDTO;
 import com.study.dto.response.StoreResponseDTO;
-import com.study.service.MemberMissionService.MemberMissionCommandService;
 import com.study.service.MissionService.MissionQueryService;
-import com.study.service.ReviewService.ReviewCommandService;
 import com.study.service.ReviewService.ReviewQueryService;
 import com.study.service.StoreService.StoreCommandService;
-import com.study.service.StoreService.StoreQueryService;
+import com.study.validation.annotation.CheckPage;
 import com.study.validation.annotation.ExistStore;
-import com.sun.source.doctree.SummaryTree;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -31,9 +24,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/stores/")
@@ -59,7 +54,12 @@ public class StoreRestController {
     @Parameters({
             @Parameter(name = "storeId", description = "가게의 아이디, path variable 입니다!")
     })
-    public ApiResponse<ReviewResponseDTO.ReviewPreViewListDTO> getReviewList(@ExistStore @PathVariable(name = "storeId") Long storeId, @RequestParam(name = "page") Integer page){
+    public ApiResponse<ReviewResponseDTO.ReviewPreViewListDTO> getReviewList(
+            @ExistStore @PathVariable(name = "storeId") Long storeId,
+            @CheckPage Integer page){
+
+        log.info("Page received in controller (after transformation): {}", page); // 디버깅 로그
+
         Page<Review> reviewList = reviewQueryService.getReviewList(storeId, page);
         return ApiResponse.onSuccess(ReviewConverter.reviewPreViewListDTO(reviewList));
     }
@@ -75,7 +75,12 @@ public class StoreRestController {
     @Parameters({
             @Parameter(name = "storeId", description = "가게의 아이디, path variable 입니다!")
     })
-    public ApiResponse<MissionResponseDTO.MissionPreViewListDTO> getMissionList(@ExistStore @PathVariable(name = "storeId") Long storeId, @RequestParam(name = "page") Integer page){
+    public ApiResponse<MissionResponseDTO.MissionPreViewListDTO> getMissionList(
+            @ExistStore @PathVariable(name = "storeId") Long storeId,
+            @CheckPage Integer page){
+
+        log.info("Page received in controller (after transformation): {}", page); // 디버깅 로그
+
         Page<Mission> missionList = missionQueryService.getMissionList(storeId, page);
         return ApiResponse.onSuccess(MissionConverter.missionPreViewListDTO(missionList));
     }

--- a/src/main/java/com/study/service/MissionService/MissionQueryServiceImpl.java
+++ b/src/main/java/com/study/service/MissionService/MissionQueryServiceImpl.java
@@ -5,6 +5,7 @@ import com.study.domain.Store;
 import com.study.repository.MissionRepository.MissionRepository;
 import com.study.repository.StoreRepository.StoreRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -38,6 +40,9 @@ public class MissionQueryServiceImpl implements MissionQueryService {
 
     @Override
     public Page<Mission> getMissionList(Long StoreId, Integer page) {
+        log.info("Page passed to repository: {}", page); // 디버깅 로그
+
+
         Store store = storeRepository.findById(StoreId).get();
         Page<Mission> missionPage = missionRepository.findAllByStore(store, PageRequest.of(page,10));
         return missionPage;

--- a/src/main/java/com/study/service/ReviewService/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/study/service/ReviewService/ReviewQueryServiceImpl.java
@@ -6,6 +6,7 @@ import com.study.repository.ReviewRepository.ReviewRepository;
 import com.study.repository.ReviewRepository.ReviewRepositoryCustom;
 import com.study.repository.StoreRepository.StoreRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +14,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -35,8 +37,11 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
         return reviewsPage;
     }
 
+
     @Override
     public Page<Review> getReviewList(Long StoreId, Integer page) {
+        log.info("Page passed to repository: {}", page); // 디버깅 로그
+
         Store store = storeRepository.findById(StoreId).get();
         Page<Review> reviewPage = reviewRepository.findAllByStore(store, PageRequest.of(page,10));
         return reviewPage;

--- a/src/main/java/com/study/service/StoreService/StoreQueryService.java
+++ b/src/main/java/com/study/service/StoreService/StoreQueryService.java
@@ -11,5 +11,7 @@ public interface StoreQueryService {
     Optional<Store> findStore(Long id);
     List<Store> findStoresByNameAndScore(String name, Float score);
 
+    Boolean existsById(Long storeId);
+
 
 }

--- a/src/main/java/com/study/service/StoreService/StoreQueryServiceImpl.java
+++ b/src/main/java/com/study/service/StoreService/StoreQueryServiceImpl.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 public class StoreQueryServiceImpl implements StoreQueryService{
     private final StoreRepository storeRepository;
-    private final ReviewRepository reviewRepository;
 
     @Override
     public Optional<Store> findStore(Long id) {
@@ -33,6 +32,11 @@ public class StoreQueryServiceImpl implements StoreQueryService{
         filteredStores.forEach(store -> System.out.println("Store: "+store));
 
         return filteredStores;
+    }
+
+    @Override
+    public Boolean existsById(Long storeId) {
+        return storeRepository.existsById(storeId);
     }
 
 

--- a/src/main/java/com/study/validation/annotation/CheckPage.java
+++ b/src/main/java/com/study/validation/annotation/CheckPage.java
@@ -1,0 +1,12 @@
+package com.study.validation.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckPage {
+
+}

--- a/src/main/java/com/study/validation/annotation/ExistMember.java
+++ b/src/main/java/com/study/validation/annotation/ExistMember.java
@@ -1,4 +1,17 @@
 package com.study.validation.annotation;
 
+import com.study.validation.validator.MemberExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = MemberExistValidator.class)
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
 public @interface ExistMember {
+    String message() default "해당 유저가 존재하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/study/validation/annotation/ExistMission.java
+++ b/src/main/java/com/study/validation/annotation/ExistMission.java
@@ -1,4 +1,18 @@
 package com.study.validation.annotation;
 
+import com.study.validation.validator.MissionExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import javax.swing.text.Element;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = MissionExistValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
 public @interface ExistMission {
+    String message() default "해당 미션이 존재하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/study/validation/annotation/ExistStore.java
+++ b/src/main/java/com/study/validation/annotation/ExistStore.java
@@ -1,4 +1,18 @@
 package com.study.validation.annotation;
 
+import com.study.validation.validator.RegionExistValidator;
+import com.study.validation.validator.StoreExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = StoreExistValidator.class)
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
 public @interface ExistStore {
+    String message() default "해당 가게가 존재하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default  {};
 }

--- a/src/main/java/com/study/validation/validator/StoreExistValidator.java
+++ b/src/main/java/com/study/validation/validator/StoreExistValidator.java
@@ -1,4 +1,32 @@
 package com.study.validation.validator;
 
-public class StoreExistValidator {
+import com.study.apiPayload.code.status.ErrorStatus;
+import com.study.service.StoreService.StoreQueryService;
+import com.study.validation.annotation.ExistMember;
+import com.study.validation.annotation.ExistStore;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StoreExistValidator implements ConstraintValidator<ExistStore, Long> {
+    private final StoreQueryService storeQueryService;
+
+    @Override
+    public void initialize(ExistStore constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long storeId, ConstraintValidatorContext context) {
+        boolean isValid = storeQueryService.existsById(storeId);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.STORE_NOT_FOUND.toString()).addConstraintViolation();
+        }
+        return isValid;
+    }
 }


### PR DESCRIPTION
## 📌 이슈 번호
This closed #25 

## 💻 작업 내용
- Custom Annotation을 통하여, query string으로 받은 Integer page 값 변환
   - **ConstraintValidator는 검증이 가능하지만, 파라미터 값을 변환하는 것은 불가능함**
   - 따라서, HandlerMethodArgumentResolver 를 사용하여 검증 및 변환을 동시에 수행해 주어야함
   
- Exception은 ErrorStatus에 정의한 형식 그대로를 사용하기 위해서 CustomException class를 작성
  - 이를 기존 ExceptionAdvice 구조를 사용하기 위해서 ExceptionAdvice에 메서드를 작성해 주었음
  
- 또한, PageHandlerResolver를 호출하기 위해서, WebConfig 클래스를 생성하고, Configuration annotation 통해서 연결
  
## 📢 기타 사항
- 기존 annotation & validator 클래스의 코드를 수정하고 보완
   - 이에 따라 existsById 메서드를 호출해야해서 service클래스의 수정도 일부 이루어짐